### PR TITLE
package.json: Update URL to match source

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     ],
     "repository": {
         "type": "url",
-        "url": "https://github.com/dcodeIO/bcrypt.js.git"
+        "url": "https://github.com/emiraydin/react-native-bcrypt.git"
     },
     "bugs": {
-        "url": "https://github.com/dcodeIO/bcrypt.js/issues"
+        "url": "https://github.com/emiraydin/react-native-bcrypt/issues"
     },
     "keywords": [
         "bcrypt",


### PR DESCRIPTION
At the time of writing, https://www.npmjs.com/package/react-native-bcrypt links to https://github.com/dcodeIO/bcrypt.js as the repository, which is confusing because it doesn't have the actual source for react-native-bcrypt.

This commit intends to fix that by updating the URL to point to https://github.com/emiraydin/react-native-bcrypt

cheers!
